### PR TITLE
Update cwpk-30-extracting-annotations.ipynb

### DIFF
--- a/cwpk-30-extracting-annotations.ipynb
+++ b/cwpk-30-extracting-annotations.ipynb
@@ -157,7 +157,7 @@
     "annot_func = ''\n",
     "annot_alt  = s_item.altLabel\n",
     "annot_def  = s_item.definition\n",
-    "annot_note = item.editorialNote\n",
+    "annot_note = s_item.editorialNote\n",
     "annot = [annot_pref, annot_sup, annot_dom, annot_rng, annot_func, annot_alt, annot_def, annot_note]\n",
     "print(annot)"
    ]


### PR DESCRIPTION
Add the correct variable's name missing the characters "s_"